### PR TITLE
Named entity fix

### DIFF
--- a/NamedEntityReplacer.py
+++ b/NamedEntityReplacer.py
@@ -31,12 +31,12 @@ def replace_named_entities(amr, sentence):
     # Remove name vars from node_to_concepts
     name_variables = [n[1] for n in named_entities]
     amr_copy.node_to_concepts = dict((key, value) for key, value in amr_copy.node_to_concepts.iteritems()
-                                if key not in name_variables)
+                                     if key not in name_variables)
 
     # Remove literals from node_to_tokens
     literals = sum([n[2] for n in named_entities], [])
     amr_copy.node_to_tokens = dict((key, value) for key, value in amr_copy.node_to_tokens.iteritems()
-                              if key not in literals)
+                                   if key not in literals)
 
     # Remove name vars and literals from amr_copy dict
     for l in literals:
@@ -52,7 +52,8 @@ def replace_named_entities(amr, sentence):
         if "wiki" in amr_copy[name_root].keys():
             if amr_copy[name_root]["wiki"][0] in amr_copy.keys():
                 amr_copy.pop(amr_copy[name_root]["wiki"][0])
-        amr_copy[name_root] = {}
+        amr_copy[name_root] = dict(
+            (key, value) for key, value in amr_copy[name_root].iteritems() if key != "name" and key != "wiki")
 
     # Add name root vars in node_to_tokens and update incrementally the token indices of the affected nodes
     named_entities = sorted(named_entities, key=itemgetter(3))
@@ -63,8 +64,8 @@ def replace_named_entities(amr, sentence):
         span_max = named_entity[4]
         for n in amr_copy.node_to_tokens:
             amr_copy.node_to_tokens[n] = [t if int(t) < span_max
-                                       else int(t) - (span_max - span_min)
-                                       for t in amr_copy.node_to_tokens[n]]
+                                          else int(t) - (span_max - span_min)
+                                          for t in amr_copy.node_to_tokens[n]]
         amr_copy.node_to_tokens[named_entity[0]] = [named_entity[3] - total_displacement]
         tokens = [tokens[:(span_min - total_displacement)] +
                   [amr_copy.node_to_concepts[named_entity[0]]] +

--- a/data_extraction_explore.ipynb
+++ b/data_extraction_explore.ipynb
@@ -1,0 +1,36 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    ""
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2.0
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/named_entities_replacement.ipynb
+++ b/named_entities_replacement.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 858,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -10,19 +10,19 @@
     {
      "ename": "ImportError",
      "evalue": "cannot import name generate_amr",
-     "output_type": "error",
      "traceback": [
       "\u001b[0;31m\u001b[0m",
       "\u001b[0;31mImportError\u001b[0mTraceback (most recent call last)",
       "\u001b[0;32m<ipython-input-858-4d61f8a594ef>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;32mfrom\u001b[0m \u001b[0mAMRGraph\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mAMR\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0;32mfrom\u001b[0m \u001b[0mAMRData\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mCustomizedAMR\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 3\u001b[0;31m \u001b[0;32mfrom\u001b[0m \u001b[0mutilities\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mpretty_print\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mgenerate_action_sequence\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mgenerate_amr\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      4\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mActionSequenceGenerator\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mNamedEntityReplacer\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
       "\u001b[0;31mImportError\u001b[0m: cannot import name generate_amr"
-     ]
+     ],
+     "output_type": "error"
     }
    ],
    "source": [
     "from AMRGraph import AMR\n",
     "from AMRData import CustomizedAMR\n",
-    "from utilities import pretty_print, generate_action_sequence, generate_amr\n",
+    "from utilities import pretty_print, generate_action_sequence, generate_custom_amr, generate_amr_with_literals\n",
     "import ActionSequenceGenerator\n",
     "import NamedEntityReplacer\n",
     "import re\n",
@@ -32,7 +32,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 826,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -61,7 +61,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 828,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -158,7 +158,7 @@
     }
    ],
    "source": [
-    "custom_amr = generate_amr(amr_string, sentence)"
+    "custom_amr = generate_custom_amr(amr, sentence)"
    ]
   },
   {
@@ -176,7 +176,7 @@
    },
    "outputs": [],
    "source": [
-    " name_nodes = [(k, amr[k][\"name\"][0]) for k in amr if amr[k] and \"name\" in amr[k]]             "
+    "name_nodes = [(k, amr[k][\"name\"][0]) for k in amr if amr[k] and \"name\" in amr[k]]"
    ]
   },
   {
@@ -297,8 +297,7 @@
     "for literals_triplet in literals_triplets:\n",
     "    literals_list = literals_triplet[2]\n",
     "    tokens = [int(amr.node_to_tokens[literal][0][0]) for literal in literals_list]\n",
-    "    named_entities.append((literals_triplet[0], literals_triplet[1], literals_triplet[2], min(tokens), max(tokens)))\n",
-    "        "
+    "    named_entities.append((literals_triplet[0], literals_triplet[1], literals_triplet[2], min(tokens), max(tokens)))"
    ]
   },
   {
@@ -787,13 +786,13 @@
     {
      "ename": "NameError",
      "evalue": "name 'NamedEntityReplacer' is not defined",
-     "output_type": "error",
      "traceback": [
       "\u001b[0;31m\u001b[0m",
       "\u001b[0;31mNameError\u001b[0mTraceback (most recent call last)",
       "\u001b[0;32m<ipython-input-857-20c8d0df197f>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0;34m(\u001b[0m\u001b[0mnew_amr\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mnew_sentence\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mnamed_entities\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mNamedEntityReplacer\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mreplace_named_entities\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mamr\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0msentence\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
       "\u001b[0;31mNameError\u001b[0m: name 'NamedEntityReplacer' is not defined"
-     ]
+     ],
+     "output_type": "error"
     }
    ],
    "source": [
@@ -807,7 +806,9 @@
     "collapsed": true
    },
    "outputs": [],
-   "source": []
+   "source": [
+    ""
+   ]
   }
  ],
  "metadata": {
@@ -819,7 +820,7 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 2.0
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",

--- a/testing.py
+++ b/testing.py
@@ -104,16 +104,23 @@ from utilities import generate_action_sequence, generate_custom_amr, generate_am
 #                     :manner~e.2 (v / vigorous~e.3)))"""
 # sentence = """It should be vigorously advocated ."""
 
-amr_str = """(b / become-01~e.6
-      :ARG1 (a / area~e.4
-            :mod (t / this~e.3))
-      :ARG2 (z / zone~e.9
-            :ARG1-of (p / prohibit-01~e.8)
-            :part-of~e.10 (c / city :wiki "Hong_Kong"
-                  :name (n / name :op1 "Hong"~e.11 :op2 "Kong"~e.12)))
-      :time (s / since~e.0
-            :op1 (t2 / then~e.1)))"""
-sentence = """Since then , this area has become a prohibited zone in Hong Kong ."""
+# amr_str = """(b / become-01~e.6
+#       :ARG1 (a / area~e.4
+#             :mod (t / this~e.3))
+#       :ARG2 (z / zone~e.9
+#             :ARG1-of (p / prohibit-01~e.8)
+#             :part-of~e.10 (c / city :wiki "Hong_Kong"
+#                   :name (n / name :op1 "Hong"~e.11 :op2 "Kong"~e.12)))
+#       :time (s / since~e.0
+#             :op1 (t2 / then~e.1)))"""
+# sentence = """Since then , this area has become a prohibited zone in Hong Kong ."""
+
+amr_str = """(p / person :wiki "Goddess"
+      :name (n / name :op1 "Goddess"~e.3)
+      :domain~e.1 (s / she~e.0)
+      :poss~e.2 (i / i~e.2)
+      :mod (a / ah~e.5))"""
+sentence = """She is my Goddess , ah ."""
 
 def test_literals(amr_str, sentence):
     (new_amr, new_sentence, named_entities) = generate_amr_with_literals(amr_str, sentence)


### PR DESCRIPTION
Modified the named entity replacer to cover the case in which the named-entity root node has other children apart the ones for "name" and "wiki".

See the named entity notebook for an example or the testing,py file.